### PR TITLE
Fix Garch opengl check, add ARC conditionals to HgiMetal.

### DIFF
--- a/pxr/imaging/garch/glPlatformContextDarwin.mm
+++ b/pxr/imaging/garch/glPlatformContextDarwin.mm
@@ -9,7 +9,7 @@
 #include "pxr/pxr.h"
 #include "glPlatformContextDarwin.h"
 
-#if defined(PXR_OPENGL_SUPPORT_ENABLED)
+#if defined(PXR_GL_SUPPORT_ENABLED)
 #ifdef ARCH_OS_OSX
 #import <AppKit/NSOpenGL.h>
 typedef NSOpenGLContext NSGLContext;
@@ -27,7 +27,7 @@ class GarchNSGLContextState::Detail
 {
 public:
     Detail() {
-#if defined(PXR_OPENGL_SUPPORT_ENABLED)
+#if defined(PXR_GL_SUPPORT_ENABLED)
         context = [NSGLContext currentContext];
 #else
         context = nil;
@@ -82,7 +82,7 @@ GarchNSGLContextState::IsValid() const
 void
 GarchNSGLContextState::MakeCurrent()
 {
-#if defined(PXR_OPENGL_SUPPORT_ENABLED)
+#if defined(PXR_GL_SUPPORT_ENABLED)
 #if defined(ARCH_OS_IPHONE)
     [EAGLContext setCurrentContext:_detail->context];
 #else
@@ -95,7 +95,7 @@ GarchNSGLContextState::MakeCurrent()
 void
 GarchNSGLContextState::DoneCurrent()
 {
-#if defined(PXR_OPENGL_SUPPORT_ENABLED)
+#if defined(PXR_GL_SUPPORT_ENABLED)
 #if defined(ARCH_OS_IPHONE)
     [EAGLContext setCurrentContext:nil];
 #else

--- a/pxr/imaging/hgiMetal/blitCmds.mm
+++ b/pxr/imaging/hgiMetal/blitCmds.mm
@@ -353,6 +353,7 @@ void HgiMetalBlitCmds::CopyBufferCpuToGpu(
         memcpy(dst + dstOffset, src, copyOp.byteSize);
     }
 
+#if defined(ARCH_OS_OSX)
     if (!sharedBuffer &&
         [metalBuffer->GetBufferId()
              respondsToSelector:@selector(didModifyRange:)]) {
@@ -364,6 +365,7 @@ void HgiMetalBlitCmds::CopyBufferCpuToGpu(
         [resource didModifyRange:range];
         ARCH_PRAGMA_POP
     }
+#endif // defined(ARCH_OS_OSX)
 }
 
 void

--- a/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
+++ b/pxr/imaging/hgiMetal/indirectCommandEncoder.mm
@@ -115,8 +115,10 @@ HgiMetalIndirectCommandEncoder::HgiMetalIndirectCommandEncoder(Hgi* hgi)
 }
 
 HgiMetalIndirectCommandEncoder::~HgiMetalIndirectCommandEncoder() {
+#if !__has_feature(objc_arc)
     [_triangleTessFactors release];
     [_quadTessFactors release];
+#endif // !__has_feature(objc_arc)
 }
 
 std::string


### PR DESCRIPTION
* Note blitCmds.mm is still using the wrong MTLResource type on L.361, which should be MTLBuffer, but that issue is addressed in the following PR: https://github.com/PixarAnimationStudios/OpenUSD/pull/3226

### Description of Change(s)

* **Garch**: Fix OpenGL support checks to not check `PXR_OPENGL_SUPPORT_ENABLED`, but instead check against the proper `PXR_GL_SUPPORT_ENABLED` preprocessor.

* **HgiMetal**: Guard the `[HgiResource didModifyRange:]` instance method invocation only for **macOS**.
  * Note `blitCmds.mm` is still using the wrong [MTLResource type, on L.361](https://github.com/dgovil/USD/commit/bb9a44034d7d2d17245d173940fbfe89e819544b#diff-9ef0251cb9e02f61313f3aa4efdc130b8deeee2c767e6926c332cae0c0cf5639R361), which should be 
    using `MTLBuffer` instead, but that issue is addressed in this PR: https://github.com/PixarAnimationStudios/OpenUSD/pull/3226

- **HgiMetal**: conditionally compile the newly added `release` calls with `!__has_feature(objc_arc)`, so this change is in line with the PR linked above.

### Checklist

- [x] I have verified that all unit tests pass with the proposed changes

- [x] I have submitted a signed Contributor License Agreement (Reference: 
[Contributor License Agreement instructions](https://openusd.org/release/contributing_to_usd.html#contributor-license-agreement))
